### PR TITLE
Prevent swag data from being cached.

### DIFF
--- a/swag_client/swag.py
+++ b/swag_client/swag.py
@@ -93,7 +93,7 @@ def upload(data, bucket, region, json_path):
     accounts = SWAGSchema(strict=True).dumps(data)
 
     s3 = boto3.cli("s3", region_name=region)
-    s3.put_object(Bucket=bucket, Key=json_path, Body=accounts)
+    s3.put_object(Bucket=bucket, Key=json_path, Body=accounts, CacheControl='no-cache, no-store, must-revalidate')
 
 
 @cache.cache(expire=3600)


### PR DESCRIPTION
There are issues with letting S3 do it's own caching. Swag should be pretty low volume, also as a source of truth, we would generally trade fresh data over speed. 