### PR TITLE
Add an option to specify a swag file instead

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,10 @@ or to filter by a service tag::
 
     service = {'services': {'YOURSERVICE': {'enabled': True, 'randomflag': True}}}
     get_all_accounts(bucket='your-swag-bucket', **service).get('accounts')
+    
+SWAG data can also be loaded from a file::
+    
+    get_all_accounts(bucket='file://my_accounts.json')
 
 Permissions required::
 
@@ -102,4 +106,3 @@ Example JSON:
 See sample_accounts.json_
 
 .. _sample_accounts.json: https://github.com/Netflix-Skunkworks/swag-client/blob/master/sample_accounts.json
-

--- a/swag_client/cli.py
+++ b/swag_client/cli.py
@@ -63,4 +63,3 @@ def table(bucket):
     """
     _table = [[result['name'], result['metadata'].get('account_number')] for result in get_all_accounts(bucket=bucket).get('accounts')]
     return tabulate(_table, headers=["Account Name", "Account Number"])
-

--- a/tests/test_swag.py
+++ b/tests/test_swag.py
@@ -78,6 +78,9 @@ def test_get_all_accounts(swag_bucket):
     data = get_all_accounts(SWAG_BUCKET, region=SWAG_BUCKET_REGION, json_path=ACCOUNTS_FILE_PATH, **{'metadata': {"s3_name": "testaccount2"}})
     assert len(data["accounts"]) == 1
 
+    data = get_all_accounts('file://tests/templates/swag_test.json')
+    assert (len(data["accounts"])) == 2
+
 def test_get_by_name(swag_data):
     # Test getting account named: "test1@test"
     account = get_by_name("test1@test", SWAG_BUCKET, region=SWAG_BUCKET_REGION, json_path=ACCOUNTS_FILE_PATH)
@@ -114,4 +117,3 @@ def test_get_by_aws_account_number(swag_data):
     # Test exception:
     with pytest.raises(InvalidSWAGDataException):
         get_by_aws_account_number("( ͡° ͜ʖ ͡°)", SWAG_BUCKET, region=SWAG_BUCKET_REGION, json_path=BAD_ACCOUNTS_FILE_PATH)
-


### PR DESCRIPTION
This commit adds an option to specify a file instead of a bucket
for loading swag data.  The way to do this is to specify
'file://<SOME_PATH>' for bucket name.