### PR TITLE
Adding a function to filter based on service enabled

### DIFF
--- a/swag_client/__about__.py
+++ b/swag_client/__about__.py
@@ -9,7 +9,7 @@ __title__ = "swag-client"
 __summary__ = ("Cloud multi-account metadata management tool.")
 __uri__ = "https://github.com/Netflix-Skunkworks/swag-client"
 
-__version__ = "0.2.9"
+__version__ = "0.2.10"
 
 
 __author__ = "The swag developers"

--- a/swag_client/tests/test_swag.py
+++ b/swag_client/tests/test_swag.py
@@ -61,6 +61,27 @@ def test_file_backend_get_all(vector_path):
     assert len(swag.get_all()) == 2
 
 
+def test_file_backend_get_service_enabled(vector_path):
+    from swag_client.backend import SWAGManager
+    from swag_client.util import parse_swag_config_options
+
+    swag_opts = {
+        'swag.data_dir': vector_path,
+        'swag.namespace': 'service_enabled',
+        'swag.cache_expires': 0
+    }
+
+    swag = SWAGManager(**parse_swag_config_options(swag_opts))
+
+    service_1_enabled = swag.get_service_enabled('service_1')
+    assert len(service_1_enabled) == 1
+    assert service_1_enabled[0]['bastion'] == 'test1.net'
+
+    service_2_enabled = swag.get_service_enabled('service_2')
+    assert len(service_2_enabled) == 1
+    assert service_2_enabled[0]['bastion'] == 'test3.net'
+
+
 def test_file_backend_update(temp_file_name):
     from swag_client.backend import SWAGManager
     from swag_client.util import parse_swag_config_options
@@ -737,4 +758,3 @@ def test_get_by_aws_account_number(s3_bucket_name):
 
     # Test by getting account that does not exist:
     assert not get_by_aws_account_number('thisdoesnotexist', s3_bucket_name)
-

--- a/swag_client/tests/vectors/service_enabled.json
+++ b/swag_client/tests/vectors/service_enabled.json
@@ -1,0 +1,83 @@
+{
+  "accounts": [
+    {
+      "description": "Test account 1",
+      "alias": [
+        "testaccnt1"
+      ],
+      "bastion": "test1.net",
+      "owners": [
+        "someadmin@test.net"
+      ],
+      "type": "aws",
+      "name": "test1@test",
+      "cmc_required": false,
+      "schema_version": 1,
+      "ours": true,
+      "metadata": {
+        "s3_name": "testaccount1",
+        "cloudtrail_index": "cloudtrail_testaccount1[yyyymm]",
+        "cloudtrail_kibana_url": "http://wouldnt/you/like/to/know",
+        "email": "testaccount1@test.net",
+        "account_number": "012345678910"
+      },
+      "id": "aws-012345678910",
+      "services": [
+        {
+          "name": "service_1",
+          "status": [{"enabled": true}]
+        },
+        {
+          "name": "service_2",
+          "status": [{"enabled": false}]
+        }
+      ]
+    },
+    {
+      "description": "Test account 2",
+      "alias": [
+        "testaccnt2"
+      ],
+      "bastion": "test2.net",
+      "owners": [
+        "someadmin@netflix.com"
+      ],
+      "type": "aws",
+      "name": "test2@test",
+      "cmc_required": false,
+      "schema_version": 1,
+      "ours": true,
+      "metadata": {
+        "s3_name": "testaccount2",
+        "cloudtrail_index": "cloudtrail_testaccount2[yyyymm]",
+        "cloudtrail_kibana_url": "http://wouldnt/you/like/to/know2",
+        "email": "testaccount2@test.net",
+        "account_number": "109876543210"
+      },
+      "id": "aws-109876543210"
+    },
+    {
+      "description": "Test account 3",
+      "alias": [
+        "testaccnt3"
+      ],
+      "bastion": "test3.net",
+      "owners": [
+        "someadmin@netflix.com"
+      ],
+      "type": "aws",
+      "name": "test3@test",
+      "cmc_required": false,
+      "schema_version": 1,
+      "ours": true,
+      
+      "id": "aws-33333333333333",
+      "services": [
+        {
+          "name": "service_2",
+          "status": [{"enabled": true}]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This commit adds a function that can either retrieve all accounts
or accept a list of accounts and then filter based on accounts
where a given service name has a status of enabled.