### PR TITLE
fix issues when you instantiate SWAGManager without options

### DIFF
--- a/swag_client/__about__.py
+++ b/swag_client/__about__.py
@@ -9,7 +9,7 @@ __title__ = "swag-client"
 __summary__ = ("Cloud multi-account metadata management tool.")
 __uri__ = "https://github.com/Netflix-Skunkworks/swag-client"
 
-__version__ = "0.3.4"
+__version__ = "0.3.5"
 
 __author__ = "The swag developers"
 __email__ = "oss@netflix.com"

--- a/swag_client/backend.py
+++ b/swag_client/backend.py
@@ -43,10 +43,8 @@ def get(name):
 class SWAGManager(object):
     """Manages swag backends."""
     def __init__(self, *args, **kwargs):
-        if not kwargs:
-            kwargs = parse_swag_config_options({})
-
-        self.configure(*args, **kwargs)
+        if kwargs:
+            self.configure(*args, **kwargs)
 
     def configure(self, *args, **kwargs):
         """Configures a SWAG manager. Overrides existing configuration."""


### PR DESCRIPTION
Fix the issue seen when instantiating a new SWAGManager without options by not calling configure at all in the init.  This will not create an accounts.json file by default anymore