### PR TITLE
Fixed bug with spinnaker metdata name being absent for downgrades

### DIFF
--- a/swag_client/__about__.py
+++ b/swag_client/__about__.py
@@ -9,7 +9,7 @@ __title__ = "swag-client"
 __summary__ = ("Cloud multi-account metadata management tool.")
 __uri__ = "https://github.com/Netflix-Skunkworks/swag-client"
 
-__version__ = "0.3.7"
+__version__ = "0.3.8"
 
 __author__ = "The swag developers"
 __email__ = "oss@netflix.com"

--- a/swag_client/migrations/versions/v2.py
+++ b/swag_client/migrations/versions/v2.py
@@ -198,7 +198,7 @@ def downgrade(account):
 
         elif service['name'] == 'spinnaker':
             v1_services['spinnaker'] = {
-                'name': service['metadata']['name'],
+                'name': service['metadata'].get('name', account["name"]),
                 'enabled': service['status'][0]['enabled']
             }
 

--- a/swag_client/tests/test_swag.py
+++ b/swag_client/tests/test_swag.py
@@ -697,6 +697,57 @@ def test_get_all_accounts(s3_bucket_name):
     assert len(data['accounts']) == 1
 
 
+def test_downgrade_spinnaker():
+    """Test without any metadata name set -- should default to the account name"""
+    from swag_client.migrations.versions.v2 import downgrade
+    account_spinnaker = {
+        "email": "spinnakertestaccount@test.com",
+        "services": [
+            {
+                "metadata": {},
+                "status": [
+                    {
+                        "region": "all",
+                        "notes": [],
+                        "enabled": True
+                    }
+                ],
+                "name": "spinnaker"
+            }
+        ],
+        "type": "service",
+        "aliases": [],
+        "description": "Spinnaker Test for Downgrade",
+        "schemaVersion": "2",
+        "id": "098765432110",
+        "name": "testspinnaker",
+        "owner": "netflix",
+        "contacts": [
+            "test@test.com"
+        ],
+        "status": [
+            {
+                "status": "created",
+                "region": "all",
+                "notes": []
+            }
+        ],
+        "sensitive": False,
+        "provider": "aws",
+        "tags": [],
+        "environment": "test"
+    }
+
+    v1 = downgrade(account_spinnaker)
+    assert v1["services"]["spinnaker"]["name"] == "testspinnaker"
+
+    # With the name set:
+    account_spinnaker["services"][0]["metadata"]["name"] = "lolaccountname"
+    v1 = downgrade(account_spinnaker)
+    assert v1["services"]["spinnaker"]["name"] == "lolaccountname"
+
+
+
 def test_get_by_name(s3_bucket_name):
     from swag_client.swag import get_by_name
 


### PR DESCRIPTION
Should resolve issues with the `metadata` for Spinnaker being blank.

This will default to the account name for the V1 downgrades.