### PR TITLE
Make field validation configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ htmlcov/
 nosetests.xml
 coverage.xml
 *,cover
+.pytest_cache/
 
 # Translations
 *.mo

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ When you're ready to configure swag:
     swag.configure(**parse_swag_config_options(swag_opts))
 ```
 
+
 ### Example Account JSON (v2)
 Below is an example of the bare minimum JSON that will be created by SWAG with `schema_version=2`.
 
@@ -287,6 +288,7 @@ Examples:
 ### Extended SWAG Schema (Version 2)
 The following describes the usage of all native fields included within the SWAG schema.
 
+
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | schemaVersion | int | Describes the current schema version |
@@ -294,15 +296,32 @@ The following describes the usage of all native fields included within the SWAG 
 | name | str | Canonical name, according to the account naming standard |
 | contacts | list(str) | List of team DLs that are majority stakeholders for the account |
 | provider | str | One of: AWS, GCP, Azure |
-| type | str | One of: Billing, Security, Shared Service, Service |
+| type | str | See schema context for field validation |
 | status | list(dict) | See status schema |
 | services | list(dict) | See service schema |
-| environment | str | One of: test, prod |
+| environment | str | See schema context for field validation |
 | sensitive | bool |  Signifies if the account holds a special significance; (in scope for PCI, holds PII, contains sensitive key material, etc.,) |
 | description | str | Brief description about the account's intended use. |
-| owner | str | One of: <company-name>, AWS, Third-Party |
+| owner | str | See schema context for field validation |
 | aliases | list(str) | List of other names this account may be referred to as |
 
+### Schmea Context for Field Validation
+The V2 schema performs validation checks on certain fields to ensure values are within a defined list.  Some of these are optional and configurable to allow users to specify values that make sense for their use case.
+
+The allowed values for `owner`, `environment` and `type` can be set during SWAGManager initialization by passing a `swag.schema_context` object as part of the swag_opts.
+
+If you do not specify a schema_context entry for a field then any value is permitted.
+
+
+```
+swag_opts = {
+    'swag.schema_context': {
+        'owner': ['netflix', 'dvd', 'aws', 'third-party'],
+        'environment': ['test', 'prod'],
+        'type': ['billing', 'security', 'shared-service', 'service']
+    }
+}
+```
 
 #### Service Schema
 

--- a/swag_client/__about__.py
+++ b/swag_client/__about__.py
@@ -9,7 +9,7 @@ __title__ = "swag-client"
 __summary__ = ("Cloud multi-account metadata management tool.")
 __uri__ = "https://github.com/Netflix-Skunkworks/swag-client"
 
-__version__ = "0.3.8"
+__version__ = "0.3.9"
 
 __author__ = "The swag developers"
 __email__ = "oss@netflix.com"

--- a/swag_client/backend.py
+++ b/swag_client/backend.py
@@ -15,7 +15,7 @@ from swag_client.exceptions import InvalidSWAGDataException
 logger = logging.getLogger(__name__)
 
 
-def validate(item, namespace='accounts', version=2, context={}):
+def validate(item, namespace='accounts', version=2, context=None):
     """Validate item against version schema.
     
     Args:

--- a/swag_client/tests/test_swag.py
+++ b/swag_client/tests/test_swag.py
@@ -1,4 +1,6 @@
 from deepdiff import DeepDiff
+from marshmallow.exceptions import ValidationError
+import pytest
 
 
 def test_upgrade_1_to_2():
@@ -856,3 +858,106 @@ def test_get_by_aws_account_number(s3_bucket_name):
 
     # Test by getting account that does not exist:
     assert not get_by_aws_account_number('thisdoesnotexist', s3_bucket_name)
+
+
+def test_schema_context_validation_type_field():
+    """Test schema context validation for type field"""
+    from swag_client.backend import SWAGManager
+    from swag_client.util import parse_swag_config_options
+
+    swag_opts = {
+        'swag.schema_context': {
+            'type': ['billing', 'security', 'shared-service', 'service'],
+        }
+    }
+    swag = SWAGManager(**parse_swag_config_options(swag_opts))
+
+    data = {
+        "aliases": ["test"],
+        "contacts": ["admins@test.net"],
+        "description": "This is just a test.",
+        "email": "test@example.net",
+        "environment": "dev",
+        "id": "012345678910",
+        "name": "testaccount",
+        "owner": "netflix",
+        "provider": "aws",
+    }
+
+    # Test with invalid account type
+    with pytest.raises(ValidationError):
+        data['type'] = 'bad_type'
+        swag.create(data)
+
+    # Test with a valid account type
+    data['type'] = 'billing'
+    account = swag.create(data)
+    assert account.get('type') == 'billing'
+
+    
+def test_schema_context_validation_environment_field():
+    """Test schema context validation for environment field"""
+    from swag_client.backend import SWAGManager
+    from swag_client.util import parse_swag_config_options
+
+    swag_opts = {
+        'swag.schema_context': {
+            'environment': ['test', 'prod']
+        }
+    }
+
+    swag = SWAGManager(**parse_swag_config_options(swag_opts))
+
+    data = {
+        "aliases": ["test"],
+        "contacts": ["admins@test.net"],
+        "description": "This is just a test.",
+        "email": "test@example.net",
+        "id": "012345678910",
+        "name": "testaccount",
+        "owner": "netflix",
+        "provider": "aws",
+    }
+
+    # Test with invalid environment
+    with pytest.raises(ValidationError):
+        data['environment'] = 'bad_environment'
+        swag.create(data)
+
+    # Test with a valid environment
+    data['environment'] = 'test'
+    account = swag.create(data)
+    assert account.get('environment') == 'test'
+
+def test_schema_context_validation_owner_field():
+    """Test schema context validation for owner field"""
+    from swag_client.backend import SWAGManager
+    from swag_client.util import parse_swag_config_options
+
+    swag_opts = {
+        'swag.schema_context': {
+            'owner': ['netflix', 'dvd', 'aws', 'third-party']
+        }
+    }
+    swag = SWAGManager(**parse_swag_config_options(swag_opts))
+
+    data = {
+        "aliases": ["test"],
+        "contacts": ["admins@test.net"],
+        "description": "This is just a test.",
+        "email": "test@example.net",
+        "id": "012345678910",
+        "name": "testaccount",
+        "environment": "test",
+        "provider": "aws",
+    }
+
+    # Test with invalid owner
+    with pytest.raises(ValidationError):
+        data['owner'] = 'bad_owner'
+        swag.create(data)
+
+    # Test with a valid owner
+    data['owner'] = 'netflix'
+    account = swag.create(data)
+    assert account.get('owner') == 'netflix' 

--- a/swag_client/util.py
+++ b/swag_client/util.py
@@ -11,6 +11,7 @@ class OptionsSchema(Schema):
     namespace = fields.String(required=True, missing='accounts')
     schema_version = fields.Integer(missing=2)  # default version to return data as
     cache_expires = fields.Integer(missing=60)
+    schema_context = fields.Dict(missing={})
 
 
 class FileOptionsSchema(OptionsSchema):


### PR DESCRIPTION
Some of the V2 Schema fields were hard-coded and specific to Netflix.  This PR allows users to pass in a 'swag.schema_context' at SWAGManager init for the following fields:

- owner
- environment
- type

The 'status' and 'provider' fields were left alone as they are generic and sensible for almost all use cases.