### PR TITLE
Update v2.py

### DIFF
--- a/swag_client/schemas/v2.py
+++ b/swag_client/schemas/v2.py
@@ -9,7 +9,7 @@ ACCOUNT_STATUSES = ['created', 'in-progress', 'ready', 'deprecated', 'deleted', 
 
 
 class NoteSchema(Schema):
-    date = fields.Date()
+    date = fields.Str()
     text = fields.Str(required=True)
 
 


### PR DESCRIPTION
I propose that the __date__ field on the NoteSchema is String rather than Date. The reason is that when you use Notes, neither neither with type __file__ or __dynamodb__, it can be serialized to the destination storage. So notes are not usable right now.