### PR TITLE
Upgrade mashmallow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 matrix:
   include:
-    - python: "2.7"
     - python: "3.6"
 
 before_install:

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ with open(os.path.join(ROOT, "swag_client", "__about__.py")) as f:
 
 
 install_requires = [
-    'marshmallow==3.5.0',
+    'marshmallow>=3.5.0',
     'boto3>=1.3.7',
     'tabulate>=0.7.7',
     'dogpile.cache>=0.6.4',

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ with open(os.path.join(ROOT, "swag_client", "__about__.py")) as f:
 
 
 install_requires = [
-    'marshmallow>=2.13.5,<3.0.0',
+    'marshmallow==3.5.0',
     'boto3>=1.3.7',
     'tabulate>=0.7.7',
     'dogpile.cache>=0.6.4',

--- a/swag_client/__about__.py
+++ b/swag_client/__about__.py
@@ -9,7 +9,7 @@ __title__ = "swag-client"
 __summary__ = ("Cloud multi-account metadata management tool.")
 __uri__ = "https://github.com/Netflix-Skunkworks/swag-client"
 
-__version__ = "0.4.7"
+__version__ = "1.0.0"
 
 __author__ = "The swag developers"
 __email__ = "oss@netflix.com"

--- a/swag_client/__about__.py
+++ b/swag_client/__about__.py
@@ -9,7 +9,7 @@ __title__ = "swag-client"
 __summary__ = ("Cloud multi-account metadata management tool.")
 __uri__ = "https://github.com/Netflix-Skunkworks/swag-client"
 
-__version__ = "1.0.0"
+__version__ = "3.0.0"
 
 __author__ = "The swag developers"
 __email__ = "oss@netflix.com"

--- a/swag_client/backend.py
+++ b/swag_client/backend.py
@@ -28,8 +28,6 @@ def validate(item, namespace='accounts', version=2, context=None):
         if version == 2:
             schema = v2.AccountSchema(context=context)
             return schema.load(item)
-        #elif version == 1:
-            #return v1.AccountSchema().load(item)
         raise InvalidSWAGDataException('Schema version is not supported. Version: {}'.format(version))
     raise InvalidSWAGDataException('Namespace not supported. Namespace: {}'.format(namespace))
 

--- a/swag_client/backend.py
+++ b/swag_client/backend.py
@@ -26,10 +26,10 @@ def validate(item, namespace='accounts', version=2, context=None):
     """
     if namespace == 'accounts':
         if version == 2:
-            schema = v2.AccountSchema(strict=True, context=context)
-            return schema.load(item).data
-        elif version == 1:
-            return v1.AccountSchema(strict=True).load(item).data
+            schema = v2.AccountSchema(context=context)
+            return schema.load(item)
+        #elif version == 1:
+            #return v1.AccountSchema().load(item)
         raise InvalidSWAGDataException('Schema version is not supported. Version: {}'.format(version))
     raise InvalidSWAGDataException('Namespace not supported. Namespace: {}'.format(namespace))
 

--- a/swag_client/backend.py
+++ b/swag_client/backend.py
@@ -28,6 +28,8 @@ def validate(item, namespace='accounts', version=2, context=None):
         if version == 2:
             schema = v2.AccountSchema(context=context)
             return schema.load(item)
+        elif version == 1:
+            return v1.AccountSchema().load(item)
         raise InvalidSWAGDataException('Schema version is not supported. Version: {}'.format(version))
     raise InvalidSWAGDataException('Namespace not supported. Namespace: {}'.format(namespace))
 

--- a/swag_client/schemas/v1.py
+++ b/swag_client/schemas/v1.py
@@ -31,6 +31,7 @@ TYPES = {'aws': AWSAccountSchema, 'gcp': GoogleProjectSchema}
 class AccountSchema(Schema):
     id = fields.String(required=True)
     name = fields.String(required=True)
+    email = fields.String(required=False)
     type = fields.String(required=True, validate=OneOf(TYPES.keys()))
     metadata = fields.Dict(required=True)
     tags = fields.List(fields.String())
@@ -45,9 +46,9 @@ class AccountSchema(Schema):
     # Set to False if this is a partner account your apps may need to know about.
     ours = fields.Boolean(required=True)
 
-    schema_version = fields.Integer(required=True, missing='v1')
+    schema_version = fields.Integer(missing='v1')
     account_status = fields.String(missing='created')
 
     @validates_schema
-    def validate_metadata(self, data):
-        TYPES[data['type']](many=True, strict=True).load([data['metadata']])
+    def validate_metadata(self, data, partial=False, many=False, unknown=False):
+        TYPES[data['type']](many=True).load([data['metadata']])

--- a/swag_client/schemas/v2.py
+++ b/swag_client/schemas/v2.py
@@ -46,7 +46,7 @@ class RegionSchema(Schema):
 
 
 class AccountSchema(Schema):
-    schemaVersion = fields.Str(missing='v2')
+    schemaVersion = fields.Str(missing='2')
     id = fields.Str(required=True)
     name = fields.Str(required=True)
     contacts = fields.List(fields.Email(), missing=[])

--- a/swag_client/schemas/v2.py
+++ b/swag_client/schemas/v2.py
@@ -46,10 +46,10 @@ class RegionSchema(Schema):
 
 
 class AccountSchema(Schema):
-    schemaVersion = fields.Str(missing='2')
+    schemaVersion = fields.Str(missing='v2')
     id = fields.Str(required=True)
     name = fields.Str(required=True)
-    contacts = fields.List(fields.Email(), required=True, missing=[])
+    contacts = fields.List(fields.Email(), missing=[])
     provider = fields.Str(validate=OneOf(PROVIDERS), missing='aws')
     type = fields.Str(missing='service')
     tags = fields.List(fields.Str(), missing=[])
@@ -59,7 +59,7 @@ class AccountSchema(Schema):
     services = fields.Nested(ServiceSchema, many=True, missing=[])
     sensitive = fields.Bool(missing=False)
     description = fields.Str(required=True)
-    owner = fields.Str(required=True, missing='netflix')
+    owner = fields.Str(missing='netflix')
     aliases = fields.List(fields.Str(), missing=[])
     account_status = fields.Str(validate=OneOf(ACCOUNT_STATUSES), missing='created')
     domain = fields.Str()
@@ -67,7 +67,7 @@ class AccountSchema(Schema):
     regions = fields.Dict()
 
     @validates_schema
-    def validate_type(self, data):
+    def validate_type(self, data, partial=False, many=False, unknown=False):
         """Performs field validation against the schema context
         if values have been provided to SWAGManager via the
         swag.schema_context config object.
@@ -83,7 +83,7 @@ class AccountSchema(Schema):
                 raise ValidationError('Must be one of {}'.format(allowed_values), field_names=field)
 
     @validates_schema
-    def validate_account_status(self, data):
+    def validate_account_status(self, data, partial=False, many=False, unknown=False):
         """Performs field validation for account_status.  If any
         region is not deleted, account_status cannot be deleted
         """
@@ -95,7 +95,7 @@ class AccountSchema(Schema):
                 raise ValidationError('Account Status cannot be "deleted" if a region is not "deleted"')
 
     @validates_schema
-    def validate_regions_schema(self, data):
+    def validate_regions_schema(self, data, partial=False, many=False, unknown=False):
         """Performs field validation for regions.  This should be
         a dict with region names as the key and RegionSchema as the value
         """

--- a/swag_client/swag.py
+++ b/swag_client/swag.py
@@ -36,7 +36,7 @@ def get_all_accounts(bucket, region='us-west-2', json_path='accounts.json', **fi
     swag_opts = {
         'swag.type': 's3',
         'swag.bucket_name': bucket,
-        'swag.bucket_region': region,
+        'swag.region': region,
         'swag.data_file': json_path,
         'swag.schema_version': 1
     }

--- a/swag_client/tests/test_swag.py
+++ b/swag_client/tests/test_swag.py
@@ -376,7 +376,7 @@ def test_s3_backend_delete(s3_bucket_name):
     assert len(swag.get_all()) == 1
 
 
-def xtest_s3_backend_delete_v1(s3_bucket_name):
+def test_s3_backend_delete_v1(s3_bucket_name):
     from swag_client.backend import SWAGManager
     from swag_client.util import parse_swag_config_options
 
@@ -643,7 +643,7 @@ def test_dynamodb_backend_create(dynamodb_table):
 
 
 # test backwards compatibility
-def xtest_get_all_accounts(s3_bucket_name):
+def test_get_all_accounts(s3_bucket_name):
     from swag_client.swag import get_all_accounts
 
     from swag_client.backend import SWAGManager
@@ -752,7 +752,7 @@ def test_downgrade_spinnaker():
 
 
 
-def xtest_get_by_name(s3_bucket_name):
+def test_get_by_name(s3_bucket_name):
     from swag_client.swag import get_by_name
 
     from swag_client.backend import SWAGManager
@@ -809,7 +809,7 @@ def xtest_get_by_name(s3_bucket_name):
     assert account['metadata']['account_number'] == '012345678910'
 
 
-def xtest_get_by_aws_account_number(s3_bucket_name):
+def test_get_by_aws_account_number(s3_bucket_name):
     from swag_client.swag import get_by_aws_account_number
 
     from swag_client.backend import SWAGManager

--- a/swag_client/tests/test_swag.py
+++ b/swag_client/tests/test_swag.py
@@ -376,7 +376,7 @@ def test_s3_backend_delete(s3_bucket_name):
     assert len(swag.get_all()) == 1
 
 
-def test_s3_backend_delete_v1(s3_bucket_name):
+def xtest_s3_backend_delete_v1(s3_bucket_name):
     from swag_client.backend import SWAGManager
     from swag_client.util import parse_swag_config_options
 
@@ -643,7 +643,7 @@ def test_dynamodb_backend_create(dynamodb_table):
 
 
 # test backwards compatibility
-def test_get_all_accounts(s3_bucket_name):
+def xtest_get_all_accounts(s3_bucket_name):
     from swag_client.swag import get_all_accounts
 
     from swag_client.backend import SWAGManager
@@ -752,7 +752,7 @@ def test_downgrade_spinnaker():
 
 
 
-def test_get_by_name(s3_bucket_name):
+def xtest_get_by_name(s3_bucket_name):
     from swag_client.swag import get_by_name
 
     from swag_client.backend import SWAGManager
@@ -809,7 +809,7 @@ def test_get_by_name(s3_bucket_name):
     assert account['metadata']['account_number'] == '012345678910'
 
 
-def test_get_by_aws_account_number(s3_bucket_name):
+def xtest_get_by_aws_account_number(s3_bucket_name):
     from swag_client.swag import get_by_aws_account_number
 
     from swag_client.backend import SWAGManager

--- a/swag_client/util.py
+++ b/swag_client/util.py
@@ -8,7 +8,7 @@ from marshmallow.validate import OneOf
 
 class OptionsSchema(Schema):
     type = fields.String(missing='file', validate=OneOf(['file', 's3', 'dynamodb']))
-    namespace = fields.String(required=True, missing='accounts')
+    namespace = fields.String(missing='accounts')
     schema_version = fields.Integer(missing=2)  # default version to return data as
     cache_expires = fields.Integer(missing=60)
     schema_context = fields.Dict(missing={})
@@ -46,11 +46,11 @@ def parse_swag_config_options(config):
             options[key[5:]] = val
 
     if options.get('type') == 's3':
-        return S3OptionsSchema(strict=True).load(options).data
+        return S3OptionsSchema().load(options)
     elif options.get('type') == 'dynamodb':
-        return DynamoDBOptionsSchema(strict=True).load(options).data
+        return DynamoDBOptionsSchema().load(options)
     else:
-        return FileOptionsSchema(strict=True).load(options).data
+        return FileOptionsSchema().load(options)
 
 
 def deprecated(message):


### PR DESCRIPTION
Upgrading marshmallow to v3 for validation and removing SWAG v1 functionality

SWAG v1 validation has been removed, but code has not been ripped out yet (assuming this will allow for v1 edits/upgrades, but not sure about that). Maybe we have to get rid of v2.downgrade as well?